### PR TITLE
Wording updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Once the video is ready, it will show on the screen and you can start taking scr
 
 A video's "clip" is a special portion of the video that is put in the output directory with the "clip" suffix
 (the full original video is also written).
-The clip's duration is shows by the highlighted section of the video's progress bar.
+The clip's duration is shown by the highlighted section of the video's progress bar.
 By default, the entire video is set as the clip.
 You can use the video control's to set the clip's boundaries,
 see the [Video Controls](#video-controls) section.

--- a/static/index.html
+++ b/static/index.html
@@ -45,7 +45,7 @@
                         <div class='page-section control-area'>
                             <button onclick='toggleSelection()'>Toggle Selection Box (B)</button>
                             <button onclick='captureFrame()'>Take Screenshot (F)</button>
-                            <button onclick='save()'>Save Screenshots (S)</button>
+                            <button onclick='save()'>Save Files (S)</button>
                         </div>
 
                         <div class='page-section screenshot-area'>


### PR DESCRIPTION
Changed a typo in the readme and switched the text on the "Save Screenshots" button to "Save Files" to better reflect that both screenshots and the clipped video will be saved.